### PR TITLE
Corrected misnamed option key.

### DIFF
--- a/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-result.php
+++ b/includes/admin/post-types/meta-boxes/class-wpcm-meta-box-match-result.php
@@ -79,7 +79,7 @@ class WPCM_Meta_Box_Match_Result {
 		<div id="results-table">
 
 		<?php
-		if( get_option( 'wpcm_results_box_scores' ) != 'no' ) { ?>
+		if( get_option( 'wpcm_match_box_scores' ) != 'no' ) { ?>
 
 			<table class="box-scores-table">
 				<thead>
@@ -90,7 +90,7 @@ class WPCM_Meta_Box_Match_Result {
 					</tr>
 				</thead>
 				<tbody>
-							
+
 					<?php
 					if( $sport == 'volleyball' ) :
 
@@ -229,7 +229,7 @@ class WPCM_Meta_Box_Match_Result {
 				} else { ?>
 
 					<tbody>
-						
+
 						<?php do_action('wpclubmanager_admin_results_table', $post->ID ); ?>
 						<tr>
 							<th align="right"><?php _e( 'Final Score', 'wp-club-manager' ); ?></th>
@@ -287,7 +287,7 @@ class WPCM_Meta_Box_Match_Result {
 			<?php } ?>
 
 			<?php if ( $sport == 'hockey' || $sport == 'handball' ) { ?>
-				
+
 				<p>
 					<label class="selectit">
 						<input type="checkbox" name="wpcm_shootout" id="wpcm_shootout" value="1" <?php checked( true, $shootout ); ?> />
@@ -298,7 +298,7 @@ class WPCM_Meta_Box_Match_Result {
 			<?php } ?>
 
 			<?php if ( $sport == 'soccer' ) { ?>
-				
+
 				<p>
 					<label class="selectit">
 						<input type="checkbox" name="wpcm_overtime" id="wpcm_overtime" value="1" <?php checked( true, $overtime ); ?> />

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WP Club Manager - WordPress Sports Club Plugin===
-Contributors: clubpress, leonterry, leabu85
-Tags: club, teams, sports, sports club, club management, club website, league management, league tables, team rosters, fixtures, results 
+Contributors: clubpress, leonterry, leabu85, daveyjake
+Tags: club, teams, sports, sports club, club management, club website, league management, league tables, team rosters, fixtures, results
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=ZGGZXX2EQTZ9E
 Requires at least: 4.7
 Tested up to: 5.1
@@ -16,7 +16,7 @@ WP Club Manager is a sports plugin used to create and manage a club or league we
 
 = Endorsed by USA Rugby =
 
-> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports team who wants a better website!*"  
+> "*It's perfect for the professional sports web developer and the first-time team administrator. Incredibly easy to customize and integrate, I highly recommend WP Club Manager to any sports team who wants a better website!*"
 Davey Jacobson, *Digital Platform Developer*, [USA Rugby](http://usarugby.org)
 
 = Features Include =


### PR DESCRIPTION
Previous option key `wpcm_results_box_scores` was incorrect; not found in the `wp_options` table.  The only key that was similar was `wpcm_match_box_scores`. This was preventing halftime scores from appearing if they weren't set to be hidden.